### PR TITLE
update/baoluan/update-productImpl-wrong-pageSize

### DIFF
--- a/src/main/java/com/aclass/r2sshop_ecommerce/repositories/ProductRepository.java
+++ b/src/main/java/com/aclass/r2sshop_ecommerce/repositories/ProductRepository.java
@@ -22,8 +22,8 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
     )
     List<ProductEntity> searchOrderByCategoryIdDesc(@Param("categoryId") Long categoryId, @Param("pageSize") int pageSize, @Param("startIndex") int startIndex);
 
-    @Query(nativeQuery = true, value = "select count(1) from product")
-    int getTotalRecordSearch();
+    @Query(nativeQuery = true, value = "select count(1) from product where category_id = :categoryId")
+    int getTotalRecordSearch(Long categoryId);
 
     @Query("SELECT p FROM ProductEntity p LEFT JOIN FETCH p.variantProductEntities WHERE p.id = :productId")
     Optional<ProductEntity> findProductWithVariantsById(@Param("productId") Long productId);

--- a/src/main/java/com/aclass/r2sshop_ecommerce/services/product/ProductServiceImpl.java
+++ b/src/main/java/com/aclass/r2sshop_ecommerce/services/product/ProductServiceImpl.java
@@ -60,8 +60,8 @@ public class ProductServiceImpl implements ProductService {
                 productEntities = productRepository.searchOrderByCategoryIdAsc(categoryId, pageSize, startIndex);
             }
 
-            int totalRecord = productRepository.getTotalRecordSearch();
-            int totalPage = (int) Math.ceil((double) totalRecord / pageSize) - 1;
+            int totalRecord = productRepository.getTotalRecordSearch(categoryId);
+            int totalPage = (int) Math.ceil((double) totalRecord / pageSize);
 
             List<ProductDTO> productDTOList = productEntities.stream()
                     .map(productEntity -> modelMapper.map(productEntity, ProductDTO.class))


### PR DESCRIPTION
đã sửa lỗi hiện thị sai tổng số trang
lỗi: khi lấy sản phẩm theo cateId thì lấy list theo cate nhưng totalPage hiển thị là của tổng sản phẩm đang có trong database
mô tả lỗi: ví dụ tổng sản phẩm đang có trong db là 50, lấy mỗi trang 2 sản phẩm thì sẽ có totalPage là 25
nhưng số sản phẩm cateId 1 chỉ có 10 nên khi lấy như trên thì totalPage lúc này sẽ là 5, nhưng vẫn hiển thị là 25 